### PR TITLE
Fix rematch causing host auto-drop

### DIFF
--- a/src/game/scenes/Play.ts
+++ b/src/game/scenes/Play.ts
@@ -492,7 +492,18 @@ export class Play extends Scene {
             })
             .setOrigin(0.5)
             .setInteractive({ useHandCursor: true })
-            .on("pointerup", () => this.requestRematch());
+            .on(
+                "pointerup",
+                (
+                    pointer: Phaser.Input.Pointer,
+                    _x: number,
+                    _y: number,
+                    event: Phaser.Types.Input.EventData,
+                ) => {
+                    event.stopPropagation();
+                    this.requestRematch();
+                },
+            );
 
         container.add(rematchBtn);
 


### PR DESCRIPTION
## Summary
- prevent pointerup on Rematch button from dropping the new piece

## Testing
- `npm run build` *(fails: vite not found)*