### PR TITLE
Fix RexUI integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,8 @@
 
 <body>
     <div id="root"></div>
+    <script src="https://cdn.jsdelivr.net/npm/phaser3-rex-plugins/dist/rexuiplugin.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/phaser3-rex-plugins/dist/rexinputtextplugin.min.js"></script>
     <script type="module" src="/src/main.tsx"></script>
 
 </body>

--- a/src/game/main.ts
+++ b/src/game/main.ts
@@ -47,6 +47,21 @@ const config: Phaser.Types.Core.GameConfig = {
     scene: [Boot, Preloader, Lobby, Play, GameOver],
 
     dom: { createContainer: true },
+
+    plugins: {
+        scene: [
+            {
+                key: "rexUI",
+                plugin: (window as any).rexuiplugin,
+                mapping: "rexUI",
+            },
+            {
+                key: "rexInputText",
+                plugin: (window as any).rexinputtextplugin,
+                mapping: "rexInputText",
+            },
+        ],
+    },
     
     /* 物理エンジン設定 -------------------------------------------------- */
     physics: {

--- a/src/game/scenes/Lobby.ts
+++ b/src/game/scenes/Lobby.ts
@@ -42,15 +42,25 @@ export class Lobby extends Scene {
             .setOrigin(0.5);
 
         /* ============= ① Create Room ============= */
-        this.add
-            .text(cx, 200, "Create Room", {
-                font: "24px Arial",
-                backgroundColor: "#0066cc",
-                padding: { left: 12, right: 12, top: 4, bottom: 4 },
+        const createBtn = this.rexUI
+            .add.label({
+                background: this.rexUI.add.roundRectangle(
+                    0,
+                    0,
+                    0,
+                    0,
+                    10,
+                    0x0066cc
+                ),
+                text: this.add.text(0, 0, "Create Room", {
+                    font: "24px Arial",
+                    color: "#fff",
+                }),
+                space: { left: 12, right: 12, top: 8, bottom: 8 },
             })
-            .setOrigin(0.5)
             .setInteractive({ useHandCursor: true })
             .on("pointerup", () => this.onCreate(cx));
+        createBtn.setPosition(cx, 200).setOrigin(0.5);
 
         /* ============= ② Join ============= */
         this.inputField = document.createElement("input");
@@ -60,15 +70,25 @@ export class Lobby extends Scene {
         this.inputField.style.width = "160px";
         this.add.dom(cx, 320, this.inputField);
 
-        this.add
-            .text(cx, 380, "Join", {
-                font: "24px Arial",
-                backgroundColor: "#28a745",
-                padding: { left: 28, right: 28, top: 4, bottom: 4 },
+        const joinBtn = this.rexUI
+            .add.label({
+                background: this.rexUI.add.roundRectangle(
+                    0,
+                    0,
+                    0,
+                    0,
+                    10,
+                    0x28a745
+                ),
+                text: this.add.text(0, 0, "Join", {
+                    font: "24px Arial",
+                    color: "#fff",
+                }),
+                space: { left: 28, right: 28, top: 8, bottom: 8 },
             })
-            .setOrigin(0.5)
             .setInteractive({ useHandCursor: true })
             .on("pointerup", () => this.onJoin());
+        joinBtn.setPosition(cx, 380).setOrigin(0.5);
     }
 
     /* ------------------------------------------------------------------
@@ -99,7 +119,7 @@ export class Lobby extends Scene {
             .on("pointerup", async () => {
                 try {
                     await navigator.clipboard.writeText(this.roomId);
-                    copyBtn.setText("✔︎ Copied!").setBackgroundColor("#2ecc71");
+                    copyBtn.setText("✔").setBackgroundColor("#2ecc71");
                     this.time.delayedCall(1000, () =>
                         copyBtn.setText("Copy").setBackgroundColor("#444")
                     );

--- a/src/rex-plugins.d.ts
+++ b/src/rex-plugins.d.ts
@@ -1,0 +1,15 @@
+declare global {
+    interface Window {
+        rexuiplugin: any;
+        rexinputtextplugin: any;
+    }
+}
+
+declare module "phaser" {
+    interface Scene {
+        rexUI: any;
+        rexInputText: any;
+    }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add RexUI and InputText CDN scripts
- register both RexUI plugins
- rebuild Lobby scene UI using RexUI labels
- declare RexUI global typings

## Testing
- `npm run build` *(fails: vite not found)*
- `pnpm run build` *(fails: vite not found)*
- `pnpm install` *(fails: EHOSTUNREACH)*