### PR TITLE
Update lobby scene UI with RexUI

### DIFF
--- a/src/game/scenes/Lobby.ts
+++ b/src/game/scenes/Lobby.ts
@@ -5,7 +5,6 @@ import {
     createTrysteroNetwork,
     TrysteroNetwork,
 } from "../../network/trysteroConnection";
-import { TextArea } from 'phaser3-rex-plugins/templates/ui/ui-components';
 
 /* ------------------------------------------------------------------
  * 6 桁のランダム英数字を生成するユーティリティ
@@ -20,6 +19,8 @@ export class Lobby extends Scene {
     private roomId = genRoomId();
     private inputField?: HTMLInputElement;
     private hostNet?: TrysteroNetwork;
+    private createContainer?: Phaser.GameObjects.Container;
+    private joinContainer?: Phaser.GameObjects.Container;
 
     constructor() {
         // シーンキー "Lobby" を指定して親クラス初期化
@@ -31,106 +32,110 @@ export class Lobby extends Scene {
      */
     create() {
         EventBus.emit("current-scene-ready", this);
-        const { width } = this.scale;
+        const { width, height } = this.scale;
         const cx = width / 2;
+        const cy = height / 2;
 
         /* タイトル */
-        this.rexUI.add.label({
-            x: cx,
-            y: 100,
-            text: this.add.text(0, 0, "Gundam Tower Battle – Lobby", {
-                fontSize: '28px',
-                fontFamily: 'Arial',
-                color: '#ffffff',
-            }),
-            align: 'center',    // 中央揃え
-            space: {
-                left: 0,
-                right: 0,
-                top: 0,
-                bottom: 0
-            }
-        }).setOrigin(0.5);
-
-        /* ============= ① Create Room ============= */
         this.add
-            .text(cx, 200, "Create Room", {
-                font: "24px Arial",
-                backgroundColor: "#0066cc",
-                padding: { left: 12, right: 12, top: 4, bottom: 4 },
-            })
-            .setOrigin(0.5)
-            .setInteractive({ useHandCursor: true })
-            .on("pointerup", () => this.onCreate(cx));
-
-        /* ============= ② Join ============= */
-        this.inputField = document.createElement("input");
-        this.inputField.type = "text";
-        this.inputField.maxLength = 6;
-        this.inputField.placeholder = "Enter Room ID";
-        this.inputField.style.width = "160px";
-        this.add.dom(cx, 320, this.inputField);
-
-        this.add
-            .text(cx, 380, "Join", {
-                font: "24px Arial",
-                backgroundColor: "#28a745",
-                padding: { left: 28, right: 28, top: 4, bottom: 4 },
-            })
-            .setOrigin(0.5)
-            .setInteractive({ useHandCursor: true })
-            .on("pointerup", () => this.onJoin());
-    }
-
-    /* ------------------------------------------------------------------
-     * onCreate() — 部屋作成ボタン押下時の処理
-     * ------------------------------------------------------------------ */
-    private onCreate(cx: number) {
-        /* 部屋を生成して待機 */
-        this.roomId = genRoomId();
-        this.hostNet = createTrysteroNetwork(this.roomId, true);
-
-        /* Room ID 表示 */
-        const idText = this.add
-            .text(cx, 260, `Room ID: ${this.roomId}`, {
-                font: "24px Courier",
-                color: "#ffff66",
+            .text(cx, cy - 160, "Gundam Tower Battle", {
+                fontFamily: "monospace",
+                fontSize: "32px",
+                color: "#ffffff",
             })
             .setOrigin(0.5);
 
-        /* Copy ボタン */
-        const copyBtn = this.add
-            .text(cx, 300, "Copy", {
-                font: "20px Arial",
-                backgroundColor: "#444",
-                padding: { left: 20, right: 20, top: 2, bottom: 2 },
+        /* Create Room ボタン */
+        const createBtn = this.rexUI
+            .add.label({
+                background: this.rexUI.add.roundRectangle(0, 0, 180, 40, 8, 0x6d8715),
+                text: this.add.text(0, 0, "Create Room", {
+                    fontFamily: "monospace",
+                    fontSize: "24px",
+                    color: "#ffffff",
+                }),
+                align: "center",
+                space: { left: 10, right: 10, top: 10, bottom: 10 },
+            })
+            .setOrigin(0.5)
+            .setInteractive({ useHandCursor: true })
+            .on("pointerup", () => this.showCreate());
+        this.add.existing(createBtn);
+        createBtn.setPosition(cx, cy - 40);
+
+        /* Join Room ボタン */
+        const joinBtn = this.rexUI
+            .add.label({
+                background: this.rexUI.add.roundRectangle(0, 0, 180, 40, 8, 0x6d8715),
+                text: this.add.text(0, 0, "Join Room", {
+                    fontFamily: "monospace",
+                    fontSize: "24px",
+                    color: "#ffffff",
+                }),
+                align: "center",
+                space: { left: 10, right: 10, top: 10, bottom: 10 },
+            })
+            .setOrigin(0.5)
+            .setInteractive({ useHandCursor: true })
+            .on("pointerup", () => this.showJoin());
+        this.add.existing(joinBtn);
+        joinBtn.setPosition(cx, cy + 40);
+    }
+
+    /* ------------------------------------------------------------------
+     * onJoin() — 入力された部屋IDで Play シーンへ移動
+     * ------------------------------------------------------------------ */
+    private onJoin() {
+        const id = (this.inputField?.value ?? "").trim().toUpperCase();
+        if (/^[A-Z0-9]{6}$/.test(id)) {
+            this.scene.start("Play", { roomId: id, isHost: false });
+        }
+    }
+    
+    /* ------------------------------------------------------------------
+     * showCreate() — 部屋作成ボタン押下時の処理
+     * ------------------------------------------------------------------ */
+    private showCreate() {
+        this.joinContainer?.destroy();
+        this.joinContainer = undefined;
+        this.createContainer?.destroy();
+
+        const cx = this.scale.width / 2;
+        const cy = this.scale.height / 2 + 100;
+
+        this.roomId = genRoomId();
+        this.hostNet = createTrysteroNetwork(this.roomId, true);
+
+        const idLabel = this.rexUI
+            .add.label({
+                background: this.rexUI.add.roundRectangle(0, 0, 150, 30, 6, 0x333333),
+                text: this.add.text(0, 0, `ID: ${this.roomId}`, {
+                    fontFamily: "monospace",
+                    fontSize: "20px",
+                    color: "#ffff66",
+                }),
+                space: { left: 10, right: 10, top: 8, bottom: 8 },
             })
             .setOrigin(0.5)
             .setInteractive({ useHandCursor: true })
             .on("pointerup", async () => {
                 try {
                     await navigator.clipboard.writeText(this.roomId);
-                    copyBtn.setText("✔︎ Copied!").setBackgroundColor("#2ecc71");
-                    this.time.delayedCall(1000, () =>
-                        copyBtn.setText("Copy").setBackgroundColor("#444")
-                    );
                 } catch {
-                    copyBtn.setText("Failed").setBackgroundColor("#e74c3c");
-                    this.time.delayedCall(1000, () =>
-                        copyBtn.setText("Copy").setBackgroundColor("#444")
-                    );
+                    /* noop */
                 }
             });
 
-        /* 待機中テキスト */
         const waitText = this.add
-            .text(cx, 350, "Waiting for opponent…", {
-                font: "22px Arial",
-                color: "#fff",
+            .text(0, 60, "Waiting for opponent…", {
+                fontFamily: "monospace",
+                fontSize: "18px",
+                color: "#ffffff",
             })
             .setOrigin(0.5);
 
-        /* 相手が join → Play へ遷移 */
+        this.createContainer = this.add.container(cx, cy, [idLabel, waitText]);
+
         this.hostNet.room.onPeerJoin(() => {
             waitText.setText("Opponent found!");
             this.time.delayedCall(500, () =>
@@ -144,12 +149,39 @@ export class Lobby extends Scene {
     }
 
     /* ------------------------------------------------------------------
-     * onJoin() — 入力された部屋IDで Play シーンへ移動
+     * showJoin() — 入室フォームを表示
      * ------------------------------------------------------------------ */
-    private onJoin() {
-        const id = (this.inputField?.value ?? "").trim().toUpperCase();
-        if (/^[A-Z0-9]{6}$/.test(id)) {
-            this.scene.start("Play", { roomId: id, isHost: false });
-        }
+    private showJoin() {
+        this.createContainer?.destroy();
+        this.createContainer = undefined;
+        this.joinContainer?.destroy();
+
+        const cx = this.scale.width / 2;
+        const cy = this.scale.height / 2 + 100;
+
+        this.inputField = document.createElement("input");
+        this.inputField.type = "text";
+        this.inputField.maxLength = 6;
+        this.inputField.placeholder = "Room ID";
+        this.inputField.style.width = "150px";
+        this.inputField.style.fontSize = "16px";
+        const inputDOM = this.add.dom(0, 0, this.inputField);
+
+        const joinBtn = this.rexUI
+            .add.label({
+                background: this.rexUI.add.roundRectangle(0, 0, 80, 30, 6, 0x333333),
+                text: this.add.text(0, 0, "Join", {
+                    fontFamily: "monospace",
+                    fontSize: "18px",
+                    color: "#ffffff",
+                }),
+                space: { left: 10, right: 10, top: 8, bottom: 8 },
+            })
+            .setInteractive({ useHandCursor: true })
+            .on("pointerup", () => this.onJoin());
+
+        this.joinContainer = this.add.container(cx, cy, [inputDOM, joinBtn]);
+        inputDOM.setOrigin(0.5);
+        joinBtn.setPosition(100, 0);
     }
 }


### PR DESCRIPTION
## Summary
- refactor lobby scene to use RexUI labels for buttons
- add Minecraft-inspired style for lobby menu
- display room ID with copy and show join input

## Testing
- `npm run build` *(fails: vite not found)*